### PR TITLE
Added building=retail to overpass mod

### DIFF
--- a/OverpassModule.cs
+++ b/OverpassModule.cs
@@ -432,6 +432,7 @@ namespace IndoorCO2App_Multiplatform
                 $"nwr(around:{rString},{latString},{lonString})[amenity=post_office];" +
                 $"nwr(around:{rString},{latString},{lonString})[amenity=university];" +
                 $"nwr(around:{rString},{latString},{lonString})[building=university];" +
+                $"nwr(around:{rString},{latString},{lonString})[building=retail];" +
                 $"nwr(around:{rString},{latString},{lonString})[amenity=hospital];" +
                 $"nwr(around:{rString},{latString},{lonString})[amenity=clinic];" +
                 $"nwr(around:{rString},{latString},{lonString})[amenity=dentist];" +


### PR DESCRIPTION
Hey Aurel

I tried to measure [this boba shop](https://www.openstreetmap.org/way/451762735) today and couldn't find it when I made the overpass query. Looks like its only tag is building=retail. 
So I've added that here.

Hope its helpful and hope I've done this PR the way you would like!