### PR TITLE
OverpassModule: also query rental car agencies

### DIFF
--- a/OverpassModule.cs
+++ b/OverpassModule.cs
@@ -395,6 +395,7 @@ namespace IndoorCO2App_Multiplatform
                 $"nwr(around:{rString},{latString},{lonString})[leisure=sauna];" +
                 $"nwr(around:{rString},{latString},{lonString})[leisure=hackerspace];" +
                 $"nwr(around:{rString},{latString},{lonString})[amenity=townhall];" +
+                $"nwr(around:{rString},{latString},{lonString})[amenity=car_rental];" +
                 $"nwr(around:{rString},{latString},{lonString})[amenity=convention_centre];" +
                 $"nwr(around:{rString},{latString},{lonString})[amenity=conference_centre];" +
                 $"nwr(around:{rString},{latString},{lonString})[amenity=congress_centre];" +


### PR DESCRIPTION
Car rental agencies are often tagged as amenity=car_rental.

Examples:
- Edinburgh Aiport Car Rental Center: https://www.openstreetmap.org/node/13100034143
- Boston Airport Car Rental Center: https://www.openstreetmap.org/node/12108234765